### PR TITLE
Team 5 Hello world graph

### DIFF
--- a/hello_world_graph/hello.cc
+++ b/hello_world_graph/hello.cc
@@ -1,0 +1,6 @@
+#include <iostream>
+
+int main() {
+    std::cout << "Hello, World!" << std::endl;
+    return 0;
+}

--- a/hello_world_graph/ninja
+++ b/hello_world_graph/ninja
@@ -1,0 +1,1 @@
+../build-cmake/ninja

--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -1616,9 +1616,61 @@ NORETURN void real_main(int argc, char** argv) {
   exit(1);
 }
 
+void compile_hello(int argc, char** argv) {
+  const char* ninja_command = argv[0];
+  BuildConfig config;
+  Options options = {};
+
+  int exit_code = ReadFlags(&argc, &argv, &options, &config);
+  if (exit_code >= 0)
+    exit(exit_code);
+
+  Status* status = Status::factory(config);
+
+  NinjaMain ninja(ninja_command, config);
+
+  string* err;
+
+  // start building hello world graph
+
+  Rule* rule_compile = new Rule("compile");
+  EvalString value1;
+  value1.AddText("g++ -c ");
+  value1.AddSpecial("in");
+  value1.AddText(" -o ");
+  value1.AddSpecial("out");
+  rule_compile->AddBinding("command", value1);
+
+  Rule* rule_link = new Rule("link");
+  EvalString value2;
+  value2.AddText("g++ ");
+  value2.AddSpecial("in");
+  value2.AddText(" -o ");
+  value2.AddSpecial("out");
+  rule_link->AddBinding("command", value2);
+
+  Edge* edge_compile = ninja.state_.AddEdge(rule_compile);
+
+  ninja.state_.AddOut(edge_compile, "hello.o", 0, err);
+  ninja.state_.AddIn(edge_compile, "hello.cc", 0);
+
+  Edge* edge_link = ninja.state_.AddEdge(rule_link);
+
+  ninja.state_.AddOut(edge_link, "hello", 0, err);
+  ninja.state_.AddIn(edge_link, "hello.o", 0);
+
+  int result = ninja.RunBuild(argc, argv, status);
+  exit(result);
+}
+
 }  // anonymous namespace
 
 int main(int argc, char** argv) {
+  if(argc == 2 && !strcmp(argv[1], "hello"))
+  {
+    compile_hello(argc, argv);
+    return 0;
+  }
 #if defined(_MSC_VER)
   // Set a handler to catch crashes not caught by the __try..__except
   // block (e.g. an exception in a stack-unwind-block).


### PR DESCRIPTION
This PR is an experiment that adds a build option to Ninja, allowing it to skip the parsing step (i.e., parsing `build.ninja`) and instead manually set up the dependency graph in memory, passing it directly to `runBuild`.

To use it, after building Ninja, run `./ninja hello` inside the `hello_world_graph` folder. This will generate the "Hello World" binary without the need for a `build.ninja` file.

---

#### Why use a command-line option (i.e., requiring `hello` to be passed to `ninja`) instead of creating a separate build binary specifically for the "Hello World" program (e.g., running `./ninja_hello` directly in the `hello_world_graph` folder)?

While it is possible to create a dedicated binary, which would be clearer, all the relevant classes like `NinjaMain` exist only in `ninja.cc`, and there isn’t something like a `ninja.h` header file. In order to use `NinjaMain` to continue the build process after the graph is created, we would need to refactor `ninja.cc` into a header file (`ninja.h`) so that other source files could utilize `NinjaMain`.

Since I guess this task is more of an experiment, I have not done that refactoring at this point.